### PR TITLE
Fixing reference tag in scopes put body schema

### DIFF
--- a/spec/connected_app.yml
+++ b/spec/connected_app.yml
@@ -341,4 +341,4 @@ components:
           type: array
           title: scopes
           items:
-            type: '#/components/schemas/scopeCore'
+            $ref: '#/components/schemas/scopeCore'


### PR DESCRIPTION
Wrong use of "type" instead of "$ref" generated a bug in Go code causing the following error while compiling the provider:

❯ go build -o terraform-provider-anypoint
github.com/mulesoft-consulting/anypoint-client-go/connected_app
../../../../go/pkg/mod/github.com/mulesoft-consulting/anypoint-client-go/connected_app@v0.0.1/model_connected_app_scopes_put_body.go:19:12: undefined: ComponentsSchemasScopeCore
../../../../go/pkg/mod/github.com/mulesoft-consulting/anypoint-client-go/connected_app@v0.0.1/model_connected_app_scopes_put_body.go:40:51: undefined: ComponentsSchemasScopeCore
../../../../go/pkg/mod/github.com/mulesoft-consulting/anypoint-client-go/connected_app@v0.0.1/model_connected_app_scopes_put_body.go:42:13: undefined: ComponentsSchemasScopeCore
../../../../go/pkg/mod/github.com/mulesoft-consulting/anypoint-client-go/connected_app@v0.0.1/model_connected_app_scopes_put_body.go:50:55: undefined: ComponentsSchemasScopeCore
../../../../go/pkg/mod/github.com/mulesoft-consulting/anypoint-client-go/connected_app@v0.0.1/model_connected_app_scopes_put_body.go:67:51: undefined: ComponentsSchemasScopeCore